### PR TITLE
Refactor browser action event listener

### DIFF
--- a/background.js
+++ b/background.js
@@ -107,17 +107,8 @@ browser.browserAction.onClicked.addListener((e) => {
             return;
         }
 
-        browser.tabs.query({
-            'url': notificationsUrl,
+        browser.tabs.update(tabs[0].id, {
             'active': true
-        }, (activeTabs) => {
-            if (activeTabs.length) {
-                return;
-            }
-
-            browser.tabs.update(tabs[0].id, {
-                'active': true
-            });
         });
     });
 });


### PR DESCRIPTION
This is a minor refactor PR which removes the second query to fetch active tab with `https://github.com/notifications` as it is not really required. If the tab exists, we can just set the tab to be active.

@AngelFQC Do let me know if I missed something.