### PR TITLE
fix: match tabs by pattern

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,6 @@
 const notificationsUrl = "https://github.com/notifications";
+// see: https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns
+const notificationsUrlPattern = "https://github.com/notifications/*";
 var count = 0;
 
 function update() {
@@ -97,7 +99,7 @@ setInterval(update, 1000 * 60);
 
 browser.browserAction.onClicked.addListener((e) => {
     browser.tabs.query({
-        'url': notificationsUrl
+        'url': notificationsUrlPattern
     }, (tabs) => {
         if (!tabs.length) {
             browser.tabs.create({


### PR DESCRIPTION
Using the tabs query [API][1], we can match the notification URL [by pattern][2] which adds support for the beta program.

Closes #13 

[1]: https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query
[2]: https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns